### PR TITLE
ERA-668 Maven plugin fails on Windows

### DIFF
--- a/src/main/java/com/digitalasset/damlmavenplugin/CodeGen.java
+++ b/src/main/java/com/digitalasset/damlmavenplugin/CodeGen.java
@@ -133,20 +133,11 @@ public class CodeGen extends MojoBase {
     private static String getDamlVersion() throws MojoFailureException {
         String errorMsg =
                 "Cannot determine project sdk version. Make sure that `daml.yaml` includes a line specifying `sdk-version`.";
-        try {
-            InputStream in = Files.newInputStream(Paths.get("daml.yaml"));
-            try (Scanner scanner = new Scanner(in)) {
-                while (scanner.hasNextLine()) {
-                    String line = scanner.nextLine().trim();
-                    if (line.startsWith("sdk-version:")) {
-                        return line.substring(12).trim();
-                    }
-                }
-            } finally {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    // whatever
+        try (Scanner scanner = new Scanner(Paths.get("daml.yaml"))) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.startsWith("sdk-version:")) {
+                    return line.substring(12).trim();
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/com/digitalasset/damlmavenplugin/Commands.java
+++ b/src/main/java/com/digitalasset/damlmavenplugin/Commands.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.digitalasset.damlmavenplugin;
+
+public class Commands {
+    static final String DAML = isWindows() ? "daml.cmd" : "daml";
+
+    private static boolean isWindows() {
+        String osName = System.getProperty("os.name");
+        return osName.startsWith("Windows");
+    }
+}

--- a/src/main/java/com/digitalasset/damlmavenplugin/Compile.java
+++ b/src/main/java/com/digitalasset/damlmavenplugin/Compile.java
@@ -20,7 +20,8 @@ public class Compile extends MojoBase {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         ProcessBuilder pb =
-                new ProcessBuilder("daml", "build", "-o", darName).redirectErrorStream(true);
+                new ProcessBuilder(Commands.DAML, "build", "-o", darName).redirectErrorStream(true);
+        getLog().info("Running DAML command: " + String.join(" ", pb.command()));
         try {
             Process daml = pb.start();
             redirectOutput(daml.getInputStream());

--- a/src/main/java/com/digitalasset/damlmavenplugin/DocsGen.java
+++ b/src/main/java/com/digitalasset/damlmavenplugin/DocsGen.java
@@ -31,7 +31,7 @@ public class DocsGen extends MojoBase {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        List<String> args = new ArrayList(Arrays.asList(Commands.DAML, "damlc", "docs", "-o", docsOutput, "-f", format));
+        List<String> args = new ArrayList<>(Arrays.asList(Commands.DAML, "damlc", "docs", "-o", docsOutput, "-f", format));
         if (combined) {
             args.add("--combine");
         }

--- a/src/main/java/com/digitalasset/damlmavenplugin/DocsGen.java
+++ b/src/main/java/com/digitalasset/damlmavenplugin/DocsGen.java
@@ -31,13 +31,14 @@ public class DocsGen extends MojoBase {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        List<String> args = new ArrayList(Arrays.asList("daml", "damlc", "docs", "-o", docsOutput, "-f", format));
+        List<String> args = new ArrayList(Arrays.asList(Commands.DAML, "damlc", "docs", "-o", docsOutput, "-f", format));
         if (combined) {
             args.add("--combine");
         }
         args.addAll(damlFiles);
         ProcessBuilder pb =
                 new ProcessBuilder(args).redirectErrorStream(true);
+        getLog().info("Running DAML command: " + String.join(" ", pb.command()));
         try {
             Process daml = pb.start();
             redirectOutput(daml.getInputStream());


### PR DESCRIPTION
On Windows the `daml.cmd` should be used to start the DAML assistant. This PR fixes that.