### PR TITLE
Adding --project-root argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.daml.extensions</groupId>
   <artifactId>daml-maven-plugin</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>DAML Maven plugin</name>

--- a/src/main/java/com/daml/extensions/damlmavenplugin/Compile.java
+++ b/src/main/java/com/daml/extensions/damlmavenplugin/Compile.java
@@ -18,9 +18,12 @@ public class Compile extends MojoBase {
     @Parameter(defaultValue = "${project.build.directory}/${project.artifactId}.dar")
     String darName;
 
+    @Parameter(defaultValue = "${basedir}")
+    String projectRoot;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
         ProcessBuilder pb =
-                new ProcessBuilder(Commands.DAML, "build", "-o", darName).redirectErrorStream(true);
+                new ProcessBuilder(Commands.DAML, "build", "-o", darName, "--project-root", projectRoot).redirectErrorStream(true);
         getLog().info("Running DAML command: " + String.join(" ", pb.command()));
         try {
             Process daml = pb.start();

--- a/src/test/java/com/daml/extensions/damlmavenplugin/CompileTest.java
+++ b/src/test/java/com/daml/extensions/damlmavenplugin/CompileTest.java
@@ -23,6 +23,7 @@ public class CompileTest {
     public void noDaml() throws MojoExecutionException, MojoFailureException {
         Compile compile = new Compile();
         compile.darName = "target/test.dar";
+        compile.projectRoot = ".";
         compile.execute();
     }
 
@@ -32,6 +33,7 @@ public class CompileTest {
         try {
             Compile compile = new Compile();
             compile.darName = "target/test.dar";
+            compile.projectRoot = ".";
             compile.execute();
 
             File darFile = new File(compile.darName);


### PR DESCRIPTION
Suppose we have a multi-module maven project where there are DAML projects as sub-modules and each of them using this plugin to compile DAML. Since the build `mvn clean install` would generally be triggered from the parent module, it becomes necessary to use `--project-root` which points to the current sub-module. Hence I propose to allow this option in the plugin.